### PR TITLE
fix: Support aarch64 linux systems

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -62,6 +62,9 @@ download_release() {
 	i686)
 		arch=x86
 		;;
+	aarch64)
+		arch=arm64
+		;;
 	*)
 		arch="$(uname -m)"
 		;;


### PR DESCRIPTION
tree-sitter labels these as arm64 in the version downloads for linux, macos and windows.